### PR TITLE
[JSON] fix trailing commas in arrays

### DIFF
--- a/JSON/JSON (Basic).sublime-syntax
+++ b/JSON/JSON (Basic).sublime-syntax
@@ -186,71 +186,53 @@ contexts:
 
 ####[ Sequence ]########################################################################################################
 
-  # FIXME: trailing commas
-
   arrays:
-    - include: empty-array
+    - include: empty-arrays
     - match: \[
       scope: punctuation.definition.sequence.begin.json
-      push: inside-array
+      push:
+        - array-body
+        - array-illegal-separator
 
-  empty-array:
+  array-body:
+    - meta_scope: meta.sequence.list.json
+    - match: \]
+      scope: punctuation.definition.sequence.end.json
+      pop: 1
+    - include: array-separators
+    - include: any
+    - match: '[^\s\]]'
+      scope: invalid.illegal.expected-separator.json
+
+  array-separators:
+    - match: (?=,)
+      branch_point: array-separators
+      branch:
+        - array-separator
+        - array-illegal-separator
+
+  array-separator:
+    - match: ','
+      scope: punctuation.separator.sequence.json
+      set: array-expect-value
+
+  array-expect-value:
+    - match: (?=\])
+      fail: array-separators
+    - include: array-illegal-separator
+
+  array-illegal-separator:
+    - match: ','
+      scope: invalid.illegal.unexpected-separator.json
+    - match: (?=\S)
+      pop: 1
+
+  empty-arrays:
     - match: (\[)\s*(\])
       scope: meta.sequence.list.empty.json
       captures:
         1: punctuation.definition.sequence.begin.json
         2: punctuation.definition.sequence.end.json
-
-  inside-array:
-    - meta_scope: meta.sequence.list.json
-    - match: \]
-      scope: punctuation.definition.sequence.end.json
-      pop: 1
-    - match: (?=\S)
-      set: expect-sequence-first-item
-    # - match: '[^\s\]]'
-    #   scope: invalid.illegal.expected-any-value.json
-
-  expect-sequence-first-item:
-    - meta_scope: meta.sequence.list.json
-    - match: \]
-      scope: punctuation.definition.sequence.end.json
-      pop: 1
-    - match: ','
-      scope: invalid.illegal.expected-any-value.json
-    - match: (?=\S)
-      set: sequence-first-item
-
-  sequence-first-item:
-    - meta_scope: meta.sequence.item.first.json
-    - include: any
-    - match: (?=\S)
-      set: expect-sequence-end-or-sequence-separator
-
-  expect-sequence-end-or-sequence-separator:
-    - meta_scope: meta.sequence.list.json
-    - match: \]
-      scope: punctuation.definition.sequence.end.json
-      pop: 1
-    - match: ','
-      scope: punctuation.separator.sequence.json
-      set: expect-sequence-item
-    - match: (?=\S)
-      scope: invalid.illegal.expected-sequence-separator.json
-      pop: 1
-
-  expect-sequence-item:
-    - meta_scope: meta.sequence.list.json
-    - match: ','
-      scope: invalid.illegal.expected-any-value.json
-    - match: (?=\S)
-      set: sequence-item
-
-  sequence-item:
-    - meta_scope: meta.sequence.item.json
-    - include: any
-    - match: (?=\S)
-      set: expect-sequence-end-or-sequence-separator
 
 ####[ Mapping ]#########################################################################################################
 

--- a/JSON/JSONC.sublime-syntax
+++ b/JSON/JSONC.sublime-syntax
@@ -160,3 +160,10 @@ contexts:
     - match: '\*/'
       scope: punctuation.definition.comment.end.jsonc
       pop: 1
+
+####[ Sequence ]########################################################################################################
+
+  array-separators:
+    - match: ','
+      scope: punctuation.separator.sequence.jsonc
+      push: array-illegal-separator

--- a/JSON/tests/syntax/syntax_test_json.invalid.illegal.expected_any_value.json
+++ b/JSON/tests/syntax/syntax_test_json.invalid.illegal.expected_any_value.json
@@ -4,15 +4,18 @@
 
 [
     ,
-// ^ meta.sequence.list
-//  ^ meta.sequence.list invalid.illegal.expected-any-value
-//   ^ meta.sequence.list
+// ^^^ meta.sequence.list
+//  ^ invalid.illegal.unexpected-separator.json
 
-    1,
-//  ^ meta.sequence.item.first
+    1,,
+// ^^^^^ meta.sequence.list.json
+//  ^ constant.numeric.value.json
+//   ^ punctuation.separator.sequence.json
+//    ^ invalid.illegal.unexpected-separator.json
 
-    [, 1, 2]
-//  ^ meta.sequence.item meta.sequence.list punctuation.definition.sequence.begin.json
-//   ^ meta.sequence.item meta.sequence.list invalid.illegal.expected-any-value
-//     ^ meta.sequence.item meta.sequence.item.first
+    [, 1, 2,]
+//  ^^^^^^^^^ meta.sequence.list.json meta.sequence.list.json
+//   ^ invalid.illegal.unexpected-separator.json
+//      ^ punctuation.separator.sequence.json
+//         ^ invalid.illegal.unexpected-separator.json
 ]

--- a/JSON/tests/syntax/syntax_test_json5.meta.sequence.json5
+++ b/JSON/tests/syntax/syntax_test_json5.meta.sequence.json5
@@ -7,53 +7,52 @@
 // <- meta.sequence.list punctuation.definition.sequence.begin
 
     true,
-//  ^^^^ meta.sequence.item.first constant.language.boolean
+//  ^^^^ constant.language.boolean
 
     false,
-//  ^^^^^ meta.sequence.item constant.language.boolean
-//  ^^^^^ - meta.sequence.item.first
+//  ^^^^^ constant.language.boolean
 
     null,
-//  ^^^^ meta.sequence.item constant.language.null
+//  ^^^^ constant.language.null
 
     0,
-//  ^ meta.sequence.item meta.number.integer.decimal constant.numeric.value
+//  ^ meta.number.integer.decimal constant.numeric.value
 
     0.0,
-//  ^^^ meta.sequence.item meta.number.float.decimal constant.numeric.value
+//  ^^^ meta.number.float.decimal constant.numeric.value
 
     "value",
-//  ^^^^^^^ meta.sequence.item string.quoted.double
+//  ^^^^^^^ string.quoted.double
 
     'value',
-//  ^^^^^^^ meta.sequence.item string.quoted.single
+//  ^^^^^^^ string.quoted.single
 
     [],
-//  ^^ meta.sequence.item meta.sequence.list.empty
+//  ^^ meta.sequence.list.empty
 
     [ ],
-//  ^^^ meta.sequence.item meta.sequence.list.empty
+//  ^^^ meta.sequence.list.empty
 
     [1, 2, 3],
-//  ^ meta.sequence.item meta.sequence.list
-//   ^ meta.sequence.item meta.sequence.item.first
-//    ^ meta.sequence.item meta.sequence.list
-//      ^ meta.sequence.item meta.sequence.item - meta.sequence.item meta.sequence.item.first
-//       ^ meta.sequence.item meta.sequence.list
-//         ^ meta.sequence.item meta.sequence.item
-//          ^ meta.sequence.item meta.sequence.list
-//           ^ meta.sequence.list
-
+//  ^^^^^^^^^ meta.sequence.list
+//  ^ punctuation.definition.sequence.begin.json
+//   ^ constant.numeric.value.json5
+//    ^ punctuation.separator.sequence.jsonc
+//      ^ constant.numeric.value.json5
+//       ^ punctuation.separator.sequence.jsonc
+//         ^ constant.numeric.value.json5
+//          ^ punctuation.definition.sequence.end.json
+//           ^ punctuation.separator.sequence.jsonc
     {},
-//  ^^ meta.sequence.item meta.mapping.empty
+//  ^^ meta.mapping.empty
 
     { },
-//  ^^^ meta.sequence.item meta.mapping.empty
+//  ^^^ meta.mapping.empty
 
     { "a": 1, "b": 2, "c": 3 },
-//  ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.sequence.item meta.mapping
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.mapping
 
     { 'a': 1, 'b': 2, 'c': 3 }
-//  ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.sequence.item meta.mapping
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.mapping
 ]
 // <- meta.sequence.list punctuation.definition.sequence.end

--- a/JSON/tests/syntax/syntax_test_jsonc.meta.sequence.jsonc
+++ b/JSON/tests/syntax/syntax_test_jsonc.meta.sequence.jsonc
@@ -5,58 +5,62 @@
 
 [
 // <- meta.sequence.list punctuation.definition.sequence.begin
+    ,
+//  ^ invalid.illegal.unexpected-separator.json
 
-    true,
-//  ^^^^ meta.sequence.item.first constant.language.boolean
+    true,,
+//  ^^^^ constant.language.boolean
+//       ^ invalid.illegal.unexpected-separator.json
 
     false,
-//  ^^^^^ meta.sequence.item constant.language.boolean
+//  ^^^^^ constant.language.boolean
 
     null,
-//  ^^^^ meta.sequence.item constant.language.null
+//  ^^^^ constant.language.null
 
     0,
-//  ^ meta.sequence.item meta.number.integer.decimal constant.numeric.value
+//  ^ meta.number.integer.decimal constant.numeric.value
 
     0.0,
-//  ^^^ meta.sequence.item meta.number.float.decimal constant.numeric.value
+//  ^^^ meta.number.float.decimal constant.numeric.value
 
     "value",
-//  ^^^^^^^ meta.sequence.item string.quoted.double
+//  ^^^^^^^ string.quoted.double
 
     [],
-//  ^^ meta.sequence.item meta.sequence.list.empty
+//  ^^ meta.sequence.list.empty
 
     [ ],
-//  ^^^ meta.sequence.item meta.sequence.list.empty
+//  ^^^ meta.sequence.list.empty
 
     [1, 2
-//  ^ meta.sequence.item meta.sequence.list punctuation.definition.sequence.begin
-//   ^ meta.sequence.item meta.sequence.item.first
-//    ^ meta.sequence.item meta.sequence.list
-//      ^ meta.sequence.item meta.sequence.item
+//  ^ meta.sequence.list punctuation.definition.sequence.begin
+//    ^ meta.sequence.list
         ,
 //     ^ - invalid
-//      ^ meta.sequence.item meta.sequence.list punctuation.separator.sequence
+//      ^ meta.sequence.list punctuation.separator.sequence
         "three"
-//      ^^^^^^^ meta.sequence.item meta.sequence.item string.quoted.double - meta.mapping.key
+//      ^^^^^^^  string.quoted.double - meta.mapping.key
     ],
-//  ^ meta.sequence.item meta.sequence.list punctuation.definition.sequence.end
+//  ^ meta.sequence.list punctuation.definition.sequence.end
 //   ^ meta.sequence.list punctuation.separator.sequence
 
     {},
-//  ^^ meta.sequence.item meta.mapping.empty
+//  ^^ meta.mapping.empty
 
     { },
-//  ^^^ meta.sequence.item meta.mapping.empty
+//  ^^^ meta.mapping.empty
 
     { "a": 1, "b": 2
-//  ^^^^^^^^^^^^^^^^ meta.sequence.item meta.mapping
-//       ^ meta.sequence.item meta.mapping punctuation.separator.mapping.key-value
-//          ^ meta.sequence.item meta.mapping punctuation.separator.mapping.pair
+//  ^^^^^^^^^^^^^^^^ meta.mapping
+//       ^ meta.mapping punctuation.separator.mapping.key-value
+//          ^ meta.mapping punctuation.separator.mapping.pair
         ,
 //     ^ - invalid
         "c": 3
     }
+
+    ,
+//  ^ punctuation.separator.sequence.jsonc
 ]
 // <- meta.sequence.list punctuation.definition.sequence.end


### PR DESCRIPTION
- simplifies array contexts and scopes
- highlights leading/trailing/multiple commas invalid in JSON but not JSONC/JSON5